### PR TITLE
fix: Correct UOM Change Handling in POS Order Line

### DIFF
--- a/src/api/ADempiere/form/point-of-sales.js
+++ b/src/api/ADempiere/form/point-of-sales.js
@@ -297,7 +297,7 @@ export function updateOrderLine({
   quantity,
   price,
   discountRate,
-  uomUuid,
+  uomId,
   isAddQuantity,
   warehouseUuid
 }) {
@@ -312,7 +312,7 @@ export function updateOrderLine({
       quantity,
       price,
       discount_rate: discountRate,
-      uom_uuid: uomUuid,
+      uomId: uomId,
       is_add_quantity: isAddQuantity,
       warehouse_uuid: warehouseUuid
     }

--- a/src/components/ADempiere/Form/VPOS/Order/line/editLineMobile.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/line/editLineMobile.vue
@@ -609,7 +609,7 @@ export default {
       updateOrderLine({
         posUuid: this.currentPointOfSales.uuid,
         orderLineUuid: this.currentLine.uuid,
-        uomUuid: uom.uom.uuid
+        uomId: uom.uom.id
       })
         .then(response => {
           this.$message({

--- a/src/components/ADempiere/Form/VPOS/Order/line/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/line/index.vue
@@ -609,7 +609,7 @@ export default {
       updateOrderLine({
         posUuid: this.currentPointOfSales.uuid,
         orderLineUuid: this.currentLine.uuid,
-        uomUuid: uom.uom.uuid
+        uomId: uom.uom.id
       })
         .then(response => {
           this.$message({

--- a/src/components/ADempiere/Form/VPOS2/MainOrder/OptionLine/editLine/editUOM.vue
+++ b/src/components/ADempiere/Form/VPOS2/MainOrder/OptionLine/editLine/editUOM.vue
@@ -1,0 +1,71 @@
+<!--
+ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+-->
+
+<template>
+  <el-select
+    v-model="selectedUOM"
+    size="small"
+    style="width: 100%;"
+    @change="handleChange"
+    @visible-change="loadUOMList"
+  >
+    <el-option
+      v-for="item in uomList"
+      :key="item.uom.id"
+      :label="item.uom.name"
+      :value="item.uom.id"
+    />
+  </el-select>
+</template>
+
+<script>
+import { defineComponent, ref, computed, onMounted } from '@vue/composition-api'
+import store from '@/store'
+
+export default defineComponent({
+  name: 'editUOM',
+  props: {
+    value: {
+      type: Number,
+      required: true
+    },
+    productId: {
+      type: Number,
+      required: true
+    },
+    handleChange: {
+      type: Function,
+      default: (newValue) => {}
+    }
+  },
+  setup(props) {
+    const selectedUOM = ref(props.value)
+
+    const uomList = computed(() => {
+      return store.getters.getListUOM({ productId: props.productId })
+    })
+
+    function loadUOMList(isVisible) {
+      if (isVisible && uomList.value.length === 0) {
+        store.dispatch('findListUOM', { productId: props.productId })
+      }
+    }
+
+    onMounted(() => {
+      store.dispatch('findListUOM', { productId: props.productId })
+    })
+
+    return {
+      selectedUOM,
+      uomList,
+      loadUOMList
+    }
+  }
+})
+</script>

--- a/src/components/ADempiere/Form/VPOS2/MainOrder/OptionLine/editLine/index.vue
+++ b/src/components/ADempiere/Form/VPOS2/MainOrder/OptionLine/editLine/index.vue
@@ -192,7 +192,7 @@ along with this program. If not, see <https:www.gnu.org/licenses/>.
 </template>
 
 <script>
-import { defineComponent, computed, ref } from '@vue/composition-api'
+import { defineComponent, computed, ref, watch } from '@vue/composition-api'
 import lang from '@/lang'
 import store from '@/store'
 // Components and Mixins
@@ -243,7 +243,12 @@ export default defineComponent({
       })
     })
 
-    valueUOM.value = props.editLine.uom.uom.id
+    valueUOM.value = props.editLine.uom && props.editLine.uom.uom ? props.editLine.uom.uom.id : 0
+    watch(visible, (isVisible) => {
+      if (isVisible) {
+        valueUOM.value = props.editLine.uom && props.editLine.uom.uom ? props.editLine.uom.uom.id : 0
+      }
+    })
 
     const currency = computed(() => {
       const { price_list } = store.getters.getCurrentOrder

--- a/src/components/ADempiere/Form/VPOS2/MainOrder/editableCell.vue
+++ b/src/components/ADempiere/Form/VPOS2/MainOrder/editableCell.vue
@@ -27,10 +27,12 @@
 <script>
 import EditAmount from '@/components/ADempiere/Form/VPOS2/MainOrder/OptionLine/editLine/editAmount.vue'
 import EditQtyEntered from '@/components/ADempiere/Form/VPOS2/MainOrder/OptionLine/editLine/editQtyEntered.vue'
+import EditUOM from '@/components/ADempiere/Form/VPOS2/MainOrder/OptionLine/editLine/editUOM.vue'
 
 export default {
   name: 'EditableCell',
   components: {
+    EditUOM,
     EditAmount,
     EditQtyEntered
   },
@@ -72,6 +74,8 @@ export default {
           return this.row.isEditQtyEntered
         case 'Discount':
           return this.row.isEditDiscount
+        case 'UOM':
+          return this.row.isEditUOM
         default:
           return false
       }
@@ -83,6 +87,8 @@ export default {
           return 'EditAmount'
         case 'QtyEntered':
           return 'EditQtyEntered'
+        case 'UOM':
+          return 'EditUOM'
         default:
           return null
       }
@@ -92,9 +98,11 @@ export default {
         case 'CurrentPrice':
           return { value: Number(this.row.price) }
         case 'QtyEntered':
-          return { qty: Number(this.row.quantity_ordered) }
+          return { qty: Number(this.row.quantity) }
         case 'Discount':
           return { value: Number(this.row.discount_rate), precision: 0 }
+        case 'UOM':
+          return { value: this.row.uom && this.row.uom.uom ? this.row.uom.uom.id : 0, productId: this.row.product ? this.row.product.id : 0 }
         default:
           return {}
       }

--- a/src/components/ADempiere/Form/VPOS2/MainOrder/index.vue
+++ b/src/components/ADempiere/Form/VPOS2/MainOrder/index.vue
@@ -94,6 +94,7 @@ export default defineComponent({
   setup() {
     const currentLine = ref({})
     const isLoadingDiscount = ref(false)
+    const isLoadingUOM = ref(false)
     const isLoadingQty = ref(false)
     const isLoadingPrice = ref(false)
     const orderLineDefinition = computed(() => {
@@ -186,6 +187,7 @@ export default defineComponent({
       if (columnKey === 'CurrentPrice') row.isEditCurrentPrice = true
       if (columnKey === 'QtyEntered') row.isEditQtyEntered = true
       if (columnKey === 'Discount') row.isEditDiscount = true
+      if (columnKey === 'UOM') row.isEditUOM = true
     }
 
     function editLineExit(row, column, cell) {
@@ -193,6 +195,7 @@ export default defineComponent({
       if (columnKey === 'QtyEntered') row.isEditQtyEntered = false
       if (columnKey === 'CurrentPrice') row.isEditCurrentPrice = false
       if (columnKey === 'Discount') row.isEditDiscount = false
+      if (columnKey === 'UOM') row.isEditUOM = false
     }
 
     function updateCurrentPrice(price) {
@@ -395,9 +398,25 @@ export default defineComponent({
           return isLoadingQty.value
         case 'Discount':
           return isLoadingDiscount.value
+        case 'UOM':
+          return isLoadingUOM.value
         default:
           return false
       }
+    }
+
+    function updateUOM(uomId) {
+      const { id: lineId } = currentLine.value
+      if (!lineId) return
+      isLoadingUOM.value = true
+      store.dispatch('updateCurrentLine', {
+        lineId,
+        uom_id: uomId,
+        quantity: currentLine.value.quantity
+      }).finally(() => {
+        isLoadingUOM.value = false
+        if (currentLine.value) currentLine.value.isEditUOM = false
+      })
     }
 
     function getUpdateFunctionFor(columnName) {
@@ -408,6 +427,8 @@ export default defineComponent({
           return updateQuantity
         case 'Discount':
           return updateDiscount
+        case 'UOM':
+          return updateUOM
         default:
           return () => {}
       }
@@ -433,6 +454,8 @@ export default defineComponent({
       displayLineQtyEntered,
       editLine,
       copyCode,
+      isLoadingUOM,
+      updateUOM,
       isLoadingFor,
       getUpdateFunctionFor
     }

--- a/src/store/modules/ADempiere/form/VPOS/lines.js
+++ b/src/store/modules/ADempiere/form/VPOS/lines.js
@@ -114,6 +114,7 @@ export default {
             const listLines = getters.getListOrderLines
             listLines.push({
               isEditCurrentPrice: false,
+              isEditUOM: false,
               isEditQtyEntered: false,
               isEditDiscount: false,
               ...responseOrder,
@@ -174,6 +175,7 @@ export default {
                 ...line,
                 isEditQtyEntered: false,
                 isEditCurrentPrice: false,
+                isEditUOM: false,
                 isEditDiscount: false,
                 isLoading: false
               }
@@ -236,6 +238,7 @@ export default {
                   ...updateLineResponse,
                   isEditQtyEntered: false,
                   isEditCurrentPrice: false,
+                  isEditUOM: false,
                   isEditDiscount: false,
                   isLoading: false
                 }
@@ -243,6 +246,7 @@ export default {
               return {
                 isEditQtyEntered: false,
                 isEditCurrentPrice: false,
+                isEditUOM: false,
                 isEditDiscount: false,
                 isLoading: false,
                 ...line

--- a/src/store/modules/ADempiere/pointOfSales/orderLine/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/orderLine/actions.js
@@ -172,7 +172,6 @@ export default {
   findUom({ commit, rootGetters }, {
     productId
   }) {
-    const posUuid = rootGetters.posAttributes.currentPointOfSales.uuid
     return listProductConversionsRequest({
       id: productId
     })

--- a/src/store/modules/ADempiere/pointOfSales/orderLine/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/orderLine/actions.js
@@ -174,8 +174,7 @@ export default {
   }) {
     const posUuid = rootGetters.posAttributes.currentPointOfSales.uuid
     return listProductConversionsRequest({
-      posUuid,
-      productId
+      id: productId
     })
       .then(response => {
         return response

--- a/src/utils/ADempiere/dictionary/form/VPOS.js
+++ b/src/utils/ADempiere/dictionary/form/VPOS.js
@@ -191,15 +191,15 @@ export function displayLineQtyEntered({
 }) {
   const {
     uom,
-    quantity_ordered
+    quantity
   } = row
   let precision = 0
-  if (isEmptyValue(uom.uom)) return formatQuantity({ value: quantity_ordered })
+  if (isEmptyValue(uom.uom)) return formatQuantity({ value: quantity })
   if (!isEmptyValue(row.uom.uom.standard_precision)) {
     precision = row.uom.uom.standard_precision
   }
   return formatQuantity({
-    value: quantity_ordered,
+    value: quantity,
     precision
   })
 }


### PR DESCRIPTION
Fixes: https://github.com/Systemhaus-Westfalia/adempiere-vue/issues/25 .

 This PR fixes three bugs in the VPOS2 Point of Sale related to changing the Unit of Measure (UOM) of an order line.

### orderLine/actions.js

  The UOM dropdown in the edit popup was always empty. Fixed by passing the correct parameter (id) to listProductConversionsRequest.

### api/form/point-of-sales.js, VPOS/Order/line/index.vue, editLineMobile.vue

Changing the UOM had no effect. The API call was sending the UOM as a UUID string instead of an integer ID, which was silently ignored by Envoy. Fixed to send uomId (integer) instead of uomUuid (string).

### Multiple files

  Added full inline UOM editing to the VPOS2 order line:
  - New editUOM.vue component for inline UOM selection (same pattern as editQtyEntered.vue)
  - editableCell.vue: routes UOM column clicks to editUOM.vue
  - MainOrder/index.vue: wires the UOM cell handlers
  - lines.js: declares isEditUOM: false at object creation (Vue 2 reactivity requirement)
  - editLine/index.vue: null-safe UOM access + re-sync when popup reopens
  - VPOS.js: fixes quantity column showing blank due to wrong field name (quantity_ordered → quantity)


### Check
- Open Order in Vue POS, add products, change quantities and UOM
- Check values in Vue POS (lines and footer) after every change
- Open same Order in ZK
- Check values in Order, Orderline. Verify that values match the Vue form.
- Footer Tax matches ZK webui (C_OrderTax.TaxAmt) in all cases.

See solution in Vue POS: 
<img width="3816" height="1815" alt="image" src="https://github.com/user-attachments/assets/dc588d97-e576-4d00-82fb-c699313ac6fa" />

**Check I: Order Header**
<img width="3816" height="1815" alt="image" src="https://github.com/user-attachments/assets/d51ad889-6824-4fb3-9c28-bce55c6b31fc" />

**Check II: Order Lines**
<img width="3816" height="1815" alt="image" src="https://github.com/user-attachments/assets/66c6cda8-5c21-453c-95cf-6f4bb39fa1e9" />

**Check III: Taxes**
<img width="3816" height="1815" alt="image" src="https://github.com/user-attachments/assets/0ec52a95-7bea-49c2-abcd-12474135ad3b" />


### Dependencies
  Depends on: [Systemhaus-Westfalia/adempiere-grpc-server#<PR number>](https://github.com/Systemhaus-Westfalia/adempiere-grpc-server/pull/10)
