### PR TITLE
Bugfix/20260330 fix quantity on duplicate product

### DIFF
--- a/src/components/ADempiere/Form/VPOS2/HeaderOrder/ProductInfo/ProductListTable.vue
+++ b/src/components/ADempiere/Form/VPOS2/HeaderOrder/ProductInfo/ProductListTable.vue
@@ -225,9 +225,13 @@ export default defineComponent({
           line => line.product.id === row.product.id
         )
         if (!isEmptyValue(existingLine)) {
-          store.dispatch('updateCurrentLine', {
+          const currentUomId = existingLine.uom && existingLine.uom.uom
+            ? existingLine.uom.uom.id
+            : undefined
+          store.dispatch("updateCurrentLine", {
             lineId: existingLine.id,
-            quantity: Number(existingLine.quantity_ordered) + 1,
+            quantity: Number(existingLine.quantity) + 1,
+            uom_id: currentUomId,
             isListLine: true
           })
           close(false)

--- a/src/components/ADempiere/Form/VPOS2/HeaderOrder/ProductInfo/ProductListTable.vue
+++ b/src/components/ADempiere/Form/VPOS2/HeaderOrder/ProductInfo/ProductListTable.vue
@@ -228,7 +228,7 @@ export default defineComponent({
           const currentUomId = existingLine.uom && existingLine.uom.uom
             ? existingLine.uom.uom.id
             : undefined
-          store.dispatch("updateCurrentLine", {
+          store.dispatch('updateCurrentLine', {
             lineId: existingLine.id,
             quantity: Number(existingLine.quantity) + 1,
             uom_id: currentUomId,

--- a/src/components/ADempiere/Form/VPOS2/HeaderOrder/ProductInfo/SearchProduct.vue
+++ b/src/components/ADempiere/Form/VPOS2/HeaderOrder/ProductInfo/SearchProduct.vue
@@ -195,9 +195,11 @@ export default defineComponent({
               })
             return
           }
+          const currentUomId = isProduct.uom && isProduct.uom.uom ? isProduct.uom.uom.id : undefined
           store.dispatch('updateCurrentLine', {
             lineId: isProduct.id,
-            quantity: Number(isProduct.quantity_ordered) + 1,
+            quantity: Number(isProduct.quantity) + 1,
+            uom_id: currentUomId,
             isListLine: true
           })
             .finally(updateLineResponse => {


### PR DESCRIPTION
Closes #27

When re-adding a product that already existed in the VUE POS order with a non-default UOM, the quantity was incorrectly incremented using the base UOM quantity instead of the displayed quantity. 

See steps to reproduce in the issue.

Fixed in `ProductListTable.vue` and `SearchProduct.vue`.    